### PR TITLE
V0.2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,6 +174,8 @@ Subsequent runs on the same thread use the previously created state, together wi
 
 The server offers ways to retrieve the current thread state, the history of the runs on a thread, and the evolution of the thread states over execution of runs.
 
+Runs over the same thread can be executed on different agents, as long as the agents support the same thread state format.
+
 >
 > Note that the format of the thread state is not specified by ACP, but it is (optionally) defined in the agent ACP descriptor. If specified, it can be retrieved by the client, if not it's not accessible to the client.
 >

--- a/docs/README.md
+++ b/docs/README.md
@@ -217,14 +217,14 @@ In the sequence above:
 1. The server returns the current thread state which collects the whole chat history.
 
 ### Output Streaming
-ACP supports output streaming. Agent can stream intermediate results of a Run to provide better response time and user experience.
+ACP supports output streaming. Agent can stream partial results of a Run to provide better response time and user experience.
 
 ACP implements streaming using Server Sent Events specified here: https://html.spec.whatwg.org/multipage/server-sent-events.html.
 
 In a nutshell, the client keeps the HTTP connection open and receives a stream of events from the server, where each event carries an update of the run result.
 
 ACP supports 2 streaming modes:
-1. **result** where each event contains a full instance of the RunResult, which fully replace the previous update.
+1. **values** where each event contains a full instance of the agent output, which fully replace the previous update.
 2. **custom** where the schema of the event is left unspecified by ACP, which it can be specified in the specific agent ACP descriptor under `spec.custom_streaming_update`
 
 #### Start a Run and stream output until completion
@@ -233,22 +233,22 @@ ACP supports 2 streaming modes:
 sequenceDiagram
     participant C as ACP Client
     participant S as ACP Server
-    C->>+S: POST /runs {agent_id, input, config, metadata, streaming='result'}
+    C->>+S: POST /runs {agent_id, input, config, metadata, streaming='values'}
     S->>-C: Run={run_id, status="pending"}
     C->>+S: GET /runs/{run_id}/stream 
     rect rgb(240,240,240)
-    S->>C: StreamEvent={id="1", event="agent_event", data={run_id, type="result", result={"message": "Hello"}}}
-    S->>C: StreamEvent={id="2", event="agent_event", data={run_id, type="result", result={"message": "Hello, how"}}}
-    S->>C: StreamEvent={id="2", event="agent_event", data={run_id, type="result", result={"message": "Hello, how can"}}}
-    S->>C: StreamEvent={id="3", event="agent_event", data={run_id, type="result", result={"message": "Hello, how can I help"}}}
-    S->>C: StreamEvent={id="4", event="agent_event", data={run_id, type="result", result={"message": "Hello, how can I help you"}}}
-    S->>C: StreamEvent={id="5", event="agent_event", data={run_id, type="result", result={"message": "Hello, how can I help you today"}}}
+    S->>C: StreamEvent={id="1", event="agent_event", data={run_id, type="values", result={"message": "Hello"}}}
+    S->>C: StreamEvent={id="2", event="agent_event", data={run_id, type="values", result={"message": "Hello, how"}}}
+    S->>C: StreamEvent={id="2", event="agent_event", data={run_id, type="values", result={"message": "Hello, how can"}}}
+    S->>C: StreamEvent={id="3", event="agent_event", data={run_id, type="values", result={"message": "Hello, how can I help"}}}
+    S->>C: StreamEvent={id="4", event="agent_event", data={run_id, type="values", result={"message": "Hello, how can I help you"}}}
+    S->>C: StreamEvent={id="5", event="agent_event", data={run_id, type="values", result={"message": "Hello, how can I help you today"}}}
     S->>C: Close Connection
     end
 ```
 
 In the sequence above:
-1. The client requests to start a run on a specific agent specifying streaming mode = 'result'.
+1. The client requests to start a run on a specific agent specifying streaming mode = 'values'.
 1. The server returns a run object.
 1. The client requests the output streaming and keeps the connection open.
 1. The server returns an event with message="Hello".

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1296,7 +1296,7 @@ components:
         - type
         - run_id
         - status
-        - result
+        - value
     RunOutputStream:
       type: object
       title: Run Output Stream Event

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Agent Connect Protocol
-  version: '0.2'
+  version: '0.1'
 tags:
   - name: Agents
     description: >-
@@ -31,10 +31,11 @@ tags:
       See `Run`  and `RunOutput` models below for more info.
   - name: Threads
     description: >-
-      If supported by the agent, Run can be grouped in Threads. When a Run is
-      created without specifying a Thread ID , a new thread is automatically
-      created and a Thread ID is returned together with the created Run. At the
-      end of the Run, the server keeps a thread state associated to the thread.
+      If supported by the involved agents, Run can be grouped in Threads. When a
+      Run is created without specifying a Thread ID , a new thread is
+      automatically created and a Thread ID is returned together with the
+      created Run. At the end of the Run, the server keeps a thread state
+      associated to the thread.
 
       When a Run is created specifying a Thread ID, the agent uses the previous
       state of the thread together with the provided input. 
@@ -42,7 +43,10 @@ tags:
       A run can be created on a thread **only** if there is no run in the
       `pending` status on the same thread. 
 
-      Current thread state is accessible through this API.
+      Current thread state is accessible through the API.
+
+      Note that runs over the same thread can be executed on different agents,
+      as long as the agents support the same thread state format.
 
       See `Thread` for more info.
 paths:
@@ -1461,23 +1465,19 @@ components:
       title: Thread
       description: Detail of an empty thread to be created.
       properties:
-        agent_id:
-          type: string
-          title: Agent ID
-          description: Identifier of the agent this thread is executed on
         metadata:
           type: object
           title: Metadata
           description: Free form metadata for this thread
-      required:
-        - agent_id
     ThreadSearchRequest:
       properties:
         agent_id:
           type: string
           format: uuid
           title: Agent Id
-          description: Matches all threads associated with the specified agent ID.
+          description: >-
+            Matches all threads that have at least one Run associated with the
+            specified agent ID.
         metadata:
           type: object
           title: Metadata Filter
@@ -1504,21 +1504,17 @@ components:
       type: object
       title: Thread
       description: >-
-        Represents a collection of consecutive runs on an agent. Thread is
-        associated with a state
+        Represents a collection of consecutive runs over a thread.  Thread is
+        associated with a state. Runs for a thread can potentially happen across
+        different agents, if the state format is compatible.
       properties:
         thread_id:
           type: string
           title: Thread ID
           description: unique identifier of a thread
-        agent_id:
-          type: string
-          title: Agent ID
-          description: Identifier of the agent this thread is executed on
         metadata:
           type: object
           title: Metadata
           description: Free form metadata for this thread
       required:
         - thread_id
-        - agent_id

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -628,7 +628,7 @@ paths:
           schema:
             type: string
             format: uuid
-            title: Thread Id
+            title: Thread ID
             description: The ID of the thread.
           name: thread_id
           in: path
@@ -702,7 +702,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /runs/{run_id}/threadstate:
+  /threads/{thread_id}/runs/{run_id}/threadstate:
     get:
       tags:
         - Threads
@@ -714,6 +714,15 @@ paths:
         be used to reconstruct the evolution of the thread state in its history.
       operationId: get_run_threadstate
       parameters:
+        - description: The ID of the thread.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Thread ID
+            description: The ID of the thread.
+          name: thread_id
+          in: path
         - description: The ID of the run.
           required: true
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Agent Connect Protocol
-  version: '0.1'
+  version: '0.2'
 tags:
   - name: Agents
     description: >-
@@ -438,10 +438,10 @@ paths:
       responses:
         '200':
           description: >-
-            Stream of agent results either as `RunResult` objects or custom
-            objects, according to the specific streaming mode requested. Note
-            that the stream of events is carried using the format specified in
-            SSE spec `text/event-stream`
+            Stream of agent results either as `ValueRunResultUpdate` objects or
+            `CustomRunResultUpdate` objects, according to the specific streaming
+            mode requested. Note that the stream of events is carried using the
+            format specified in SSE spec `text/event-stream`
           content:
             text/event-stream:
               schema:
@@ -843,8 +843,8 @@ components:
               default: false
               description: >-
                 This is `true` if the agent runs can interrupt to request
-                additional input and can be subsequently resumed. If
-                missing, it means `false`
+                additional input and can be subsequently resumed. If missing, it
+                means `false`
             callbacks:
               type: boolean
               title: Callback Support
@@ -858,27 +858,27 @@ components:
               title: Streaming Modes
               description: >-
                 Supported streaming modes. If missing, streaming is not
-                supported.  If no mode is supported attempts to stream
-                output will result in an error.
+                supported.  If no mode is supported attempts to stream output
+                will result in an error.
               properties:
-                result:
+                values:
                   type: boolean
-                  title: Result Streaming
+                  title: Values Streaming
                   description: >-
-                    This is `true` if the agent supports result streaming.
-                    If `false` or missing, result streaming is not
-                    supported. Result streaming consists of a stream of
-                    objects of type `RunResult`, where each one sent over
-                    the stream fully replace the previous one.
+                    This is `true` if the agent supports values streaming. If
+                    `false` or missing, values streaming is not supported.
+                    Values streaming consists of a stream of objects of type
+                    `ValueRunResultUpdate`, where each one sent over the stream
+                    fully replace the previous one.
                 custom:
                   type: boolean
                   title: Custom Objects Streaming
                   description: >-
                     This is `true` if the agent supports custom objects
-                    streaming. If `false` or missing, custom streaming is
-                    not supported. Custom Objects streaming consists of a
-                    stream of object whose schema is specified by the agent
-                    ACP descriptor under `specs.custom_streaming_update`.
+                    streaming. If `false` or missing, custom streaming is not
+                    supported. Custom Objects streaming consists of a stream of
+                    object whose schema is specified by the agent ACP descriptor
+                    under `specs.custom_streaming_update`.
         input:
           type: object
           description: >-
@@ -920,9 +920,9 @@ components:
         custom_streaming_update:
           type: object
           description: >-
-            This describes the format of an Update in the streaming.  Must
-            be specified if `streaming.custom` capability is true and cannot
-            be specified otherwise. Format follows:
+            This describes the format of an Update in the streaming.  Must be
+            specified if `streaming.custom` capability is true and cannot be
+            specified otherwise. Format follows:
             https://spec.openapis.org/oas/v3.1.1.html#schema-object
           examples:
             - type: object
@@ -940,12 +940,11 @@ components:
         thread_state:
           type: object
           description: >-
-            This describes the format of ThreadState.  Cannot be specified
-            if `threads` capability is false. If not specified, when
-            `threads` capability is true, then the API to retrieve
-            ThreadState from a Thread or a Run is not available. This object
-            contains an instance of an OpenAPI schema object, formatted as
-            per the OpenAPI specs:
+            This describes the format of ThreadState.  Cannot be specified if
+            `threads` capability is false. If not specified, when `threads`
+            capability is true, then the API to retrieve ThreadState from a
+            Thread or a Run is not available. This object contains an instance
+            of an OpenAPI schema object, formatted as per the OpenAPI specs:
             https://spec.openapis.org/oas/v3.1.1.html#schema-object
           examples:
             - type: object
@@ -982,23 +981,23 @@ components:
         interrupts:
           type: array
           description: >-
-            List of possible interrupts that can be provided by the agent.
-            If `interrupts` capability is true, this needs to have at least
-            one item.
+            List of possible interrupts that can be provided by the agent. If
+            `interrupts` capability is true, this needs to have at least one
+            item.
           items:
             type: object
             properties:
               interrupt_type:
                 description: >-
-                  Name of this interrupt type. Needs to be unique in the
-                  list of interrupts.
+                  Name of this interrupt type. Needs to be unique in the list of
+                  interrupts.
                 title: Interrupt Type Name
                 type: string
               interrupt_payload:
                 type: object
                 description: >-
-                  This object contains an instance of an OpenAPI schema
-                  object, formatted as per the OpenAPI specs:
+                  This object contains an instance of an OpenAPI schema object,
+                  formatted as per the OpenAPI specs:
                   https://spec.openapis.org/oas/v3.1.1.html#schema-object
                 examples:
                   - type: object
@@ -1016,8 +1015,8 @@ components:
               resume_payload:
                 type: object
                 description: >-
-                  This object contains an instance of an OpenAPI schema
-                  object, formatted as per the OpenAPI specs:
+                  This object contains an instance of an OpenAPI schema object,
+                  formatted as per the OpenAPI specs:
                   https://spec.openapis.org/oas/v3.1.1.html#schema-object
                 examples:
                   - type: object
@@ -1121,7 +1120,7 @@ components:
     StreamingMode:
       type: string
       enum:
-        - result
+        - values
         - custom
     Run:
       title: Agent Run
@@ -1255,6 +1254,36 @@ components:
         - run_id
         - status
         - result
+    ValueRunResultUpdate:
+      title: Value Run Result Update
+      description: Partial result provided as value through streaming.
+      type: object
+      properties:
+        type:
+          title: Streaming Output Type
+          type: string
+          enum:
+            - values
+        run_id:
+          type: string
+          format: uuid
+          title: Run Id
+          description: The ID of the run.
+        status:
+          title: Run Status
+          description: >-
+            Status of the Run when this result was generated. This is
+            particurarly useful when this data structure is used for streaming
+            results. As the server can indicate an interrupt or an error
+            condition while streaming the result.
+          $ref: '#/components/schemas/RunStatus'
+        value:
+          $ref: '#/components/schemas/OutputSchema'
+      required:
+        - type
+        - run_id
+        - status
+        - result
     RunOutputStream:
       type: object
       title: Run Output Stream Event
@@ -1278,15 +1307,16 @@ components:
           title: Stream Event Payload
           description: >-
             A serialized JSON data structure carried in the SSE event data
-            field. The event can carry either a full `RunResult`, if streaming
-            mode is `result` or an custom update if streaming mode is `custom`
+            field. The event can carry either a full `ValueRunResultUpdate`, if
+            streaming mode is `values` or an `CustomRunResultUpdate` if
+            streaming mode is `custom`
           oneOf:
-            - $ref: '#/components/schemas/RunResult'
+            - $ref: '#/components/schemas/ValueRunResultUpdate'
             - $ref: '#/components/schemas/CustomRunResultUpdate'
           discriminator:
             propertyName: type
             mapping:
-              result: '#/components/schemas/RunResult'
+              values: '#/components/schemas/ValueRunResultUpdate'
               custom: '#/components/schemas/CustomRunResultUpdate'
       required:
         - id
@@ -1300,7 +1330,7 @@ components:
       type: object
       properties:
         type:
-          title: Output Type
+          title: Streaming Output Type
           type: string
           enum:
             - custom

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.1
 info:
   title: Agent Connect Protocol
-  version: '0.1'
+  version: '0.2'
 tags:
   - name: Agents
     description: >-


### PR DESCRIPTION

* Changed streaming mode from "result" to "values"
* Removed agent_id from thread to allow for multiple agents to be used in a thread
* Changed path for /runs/{run_id}/threadstate to /threads/{thread_id}/runs/{run_id}/threadstate to make it more explicit.
* Bumped to v0.2